### PR TITLE
Prevent smtpd from exiting if the table process' database connection fails at startup 

### DIFF
--- a/extras/tables/table-mysql/table_mysql.c
+++ b/extras/tables/table-mysql/table_mysql.c
@@ -121,7 +121,6 @@ main(int argc, char **argv)
 	}
 	if (config_connect(config) == 0) {
 		log_warnx("warn: table-mysql: could not connect");
-		return (1);
 	}
 
 	table_api_on_update(table_mysql_update);

--- a/extras/tables/table-postgres/table_postgres.c
+++ b/extras/tables/table-postgres/table_postgres.c
@@ -111,7 +111,6 @@ main(int argc, char **argv)
 	}
 	if (config_connect(config) == 0) {
 		log_warnx("warn: table-postgres: could not connect");
-		return (1);
 	}
 
 	table_api_on_update(table_postgres_update);

--- a/extras/tables/table-redis/table_redis.c
+++ b/extras/tables/table-redis/table_redis.c
@@ -100,7 +100,6 @@ main(int argc, char **argv)
 	}
 	if (config_connect(config) == 0) {
 		log_warnx("warn: table-redis: could not connect");
-		return (1);
 	}
 
 	table_api_on_update(table_redis_update);


### PR DESCRIPTION
Do not exit if the table process cannot connect to the database server, it will connect on first query
