### PR TITLE
dkim-filter: initialize PRNG before chroot

### DIFF
--- a/extras/wip/filters/filter-dkim-signer/filter_dkim_signer.c
+++ b/extras/wip/filters/filter-dkim-signer/filter_dkim_signer.c
@@ -23,6 +23,7 @@
 #include <unistd.h>
 
 #include <openssl/pem.h>
+#include <openssl/rand.h>
 #include <openssl/rsa.h>
 #include <openssl/sha.h>
 
@@ -335,6 +336,9 @@ main(int argc, char **argv)
 	filter_api_on_eom(on_eom);
 	filter_api_on_reset(on_reset);
 	filter_api_on_rollback(on_rollback);
+
+	/* initialize PRNG before chrooting */
+	RAND_status();
 
 	filter_api_loop();
 


### PR DESCRIPTION
There is a bug with dkim-signer when compiled against OpenSSL, where an OpenSSL error happens at `RSA_sign` call.

The actual error is "PRNG not seeded". It happens because the filter is run in a chroot and if OpenSSL PRNG is not seeded before chrooting, `/dev/urandom` does not exist in the chroot and the call fails.

This patch adds a call to `RAND_status` before chrooting in order to seed the PRNG. I know nothing about OpenSSL though so I'm not sure this is sufficient to keep getting new entropy once in the chroot if
needed, and also if it's the right method to acheive this (it's marked as deprecated in LibreSSL for example).