### PR TITLE
Allow user to set host and port for SpamAssassin and ClamAV filters

### DIFF
--- a/extras/wip/filters/filter-clamav/filter-clamav.8
+++ b/extras/wip/filters/filter-clamav/filter-clamav.8
@@ -22,6 +22,8 @@
 .Sh SYNOPSIS
 .Nm
 .Op Fl dv
+.Op Fl h Ar host
+.Op Fl p Ar port
 .Sh DESCRIPTION
 .Nm
 is a filter for
@@ -38,6 +40,22 @@ Debug mode, if this option is specified,
 .Nm
 will run in the foreground and log to
 .Em stderr .
+.It Fl h
+Set the ClamAV
+.Ar host
+to be used.
+.Pp
+The default
+.Ar host
+is 127.0.0.1.
+.It Fl p Ar port
+Set the
+.Ar port
+ClamAV is listening on.
+.Pp
+The default
+.Ar port
+is 3310.
 .It Fl v
 Produce more verbose output.
 .El
@@ -53,8 +71,9 @@ Non-virus mails are accepted.
 .\".Dq X-Filter-ClamAV
 .\"header.
 .Sh CLAM ANTIVIRUS CONFIGURATION
+By default
 .Nm
-expects that Clam AntiVirus's
+expects Clam AntiVirus'
 .Xr clamd 1
 to listen on 127.0.0.1 port 3310 for incoming requests.
 This requires to uncomment the TCPAddr and TCPSocket option in the default

--- a/extras/wip/filters/filter-spamassassin/filter-spamassassin.8
+++ b/extras/wip/filters/filter-spamassassin/filter-spamassassin.8
@@ -22,7 +22,9 @@
 .Sh SYNOPSIS
 .Nm
 .Op Fl dv
+.Op Fl h Ar host
 .Op Fl l Ar limit
+.Op Fl p Ar port
 .Op Fl s Ar strategy
 .Sh DESCRIPTION
 .Nm
@@ -41,6 +43,15 @@ Debug mode, if this option is specified,
 .Nm
 will run in the foreground and log to
 .Em stderr .
+.It Fl h Ar host
+Set the
+.Ar host
+that runs spamassassin's 
+.Xr spamd 1 .
+.Pp
+The default
+.Ar host
+value is localhost.
 .It Fl l Ar limit
 Set the number of bytes
 .Ar limit
@@ -52,6 +63,16 @@ The accepted values are within the range of 1 and SIZE_T_MAX.
 The default
 .Ar limit
 value is 0 (unlimited).
+.It Fl p Ar port
+Set the
+.Ar port
+that spamassassin's
+.Xr spamd 1
+listens on.
+.Pp
+The default
+.Ar port
+value is 783.
 .It Fl s Ar strategy
 Set the
 .Ar strategy
@@ -87,8 +108,9 @@ Non-spam mails are always accepted.
 .\".Dq X-Filter-SpamAssassin
 .\"header.
 .Sh SPAMASSASSIN CONFIGURATION
+The default
 .Nm
-expects that SpamAssassin's
+configuration expects SpamAssassin's
 .Xr spamd 1
 to listen on 127.0.0.1 port 783 for incoming requests.
 This matches to the default configuration of the daemon.

--- a/extras/wip/filters/filter-spamassassin/filter_spamassassin.c
+++ b/extras/wip/filters/filter-spamassassin/filter_spamassassin.c
@@ -30,8 +30,7 @@
 #include "log.h"
 #include "iobuf.h"
 
-#define SPAMASSASSIN_HOST "127.0.0.1"
-#define SPAMASSASSIN_PORT "783"
+static const char *spamassassin_host = "127.0.0.1", *spamassassin_port = "783"
 
 struct spamassassin {
 	int fd, r;
@@ -60,7 +59,7 @@ spamassassin_open(struct spamassassin *sa)
 	hints.ai_socktype = SOCK_STREAM;
 	hints.ai_protocol = IPPROTO_TCP;
 	hints.ai_flags = AI_NUMERICHOST | AI_NUMERICSERV; /* avoid failing name resolution in chroot() */
-	if ((r = getaddrinfo(SPAMASSASSIN_HOST, SPAMASSASSIN_PORT, &hints, &addresses))) {
+	if ((r = getaddrinfo(spamassassin_host, spamassassin_port, &hints, &addresses))) {
 		log_warnx("warn: open: getaddrinfo %s", gai_strerror(r));
 		return -1;
 	}
@@ -329,13 +328,19 @@ main(int argc, char **argv)
 
 	log_init(1);
 
-	while ((ch = getopt(argc, argv, "dl:s:v")) != -1) {
+	while ((ch = getopt(argc, argv, "dh:l:p:s:v")) != -1) {
 		switch (ch) {
 		case 'd':
 			d = 1;
 			break;
+		case 'h':
+			h = optarg;
+			break;
 		case 'l':
 			l = optarg;
+			break;
+		case 'p':
+			p = optarg;
 			break;
 		case 's':
 			s = optarg;
@@ -357,6 +362,15 @@ main(int argc, char **argv)
 		if (errstr)
 			fatalx("limit option is %s: %s", errstr, l);
 	}
+	
+	if (h) {
+		spamassassin_host = strip(h);
+	}
+
+	if (p) {
+		spamassassin_port = strip(p);
+	}
+
 	if (s) {
 		s = strip(s);
 		if (strncmp(s, "accept", 6) == 0)

--- a/extras/wip/filters/filter-spamassassin/filter_spamassassin.c
+++ b/extras/wip/filters/filter-spamassassin/filter_spamassassin.c
@@ -30,7 +30,7 @@
 #include "log.h"
 #include "iobuf.h"
 
-static const char *spamassassin_host = "127.0.0.1", *spamassassin_port = "783"
+static const char *spamassassin_host = "127.0.0.1", *spamassassin_port = "783";
 
 struct spamassassin {
 	int fd, r;

--- a/extras/wip/filters/filter-spamassassin/filter_spamassassin.c
+++ b/extras/wip/filters/filter-spamassassin/filter_spamassassin.c
@@ -324,7 +324,7 @@ main(int argc, char **argv)
 {
 	int ch, d = 0, v = 0;
 	const char *errstr, *l = NULL;
-	char *s = NULL;
+	char *h = NULL, *p = NULL, *s = NULL;
 
 	log_init(1);
 


### PR DESCRIPTION
These don't necessarily run on the same host as the MTA