### PR TITLE
ClamAV filter no_chroot

### DIFF
--- a/extras/wip/filters/filter-clamav/filter-clamav.8
+++ b/extras/wip/filters/filter-clamav/filter-clamav.8
@@ -22,6 +22,8 @@
 .Sh SYNOPSIS
 .Nm
 .Op Fl dv
+.Op Fl h Ar host
+.Op Fl p Ar port
 .Sh DESCRIPTION
 .Nm
 is a filter for
@@ -38,6 +40,22 @@ Debug mode, if this option is specified,
 .Nm
 will run in the foreground and log to
 .Em stderr .
+.It Fl h
+Set the ClamAV
+.Ar host
+to be used.
+.Pp
+The default
+.Ar host
+is 127.0.0.1.
+.It Fl p Ar port
+Set the
+.Ar port
+ClamAV is listening on.
+.Pp
+The default
+.Ar port
+is 3310.
 .It Fl v
 Produce more verbose output.
 .El
@@ -53,8 +71,9 @@ Non-virus mails are accepted.
 .\".Dq X-Filter-ClamAV
 .\"header.
 .Sh CLAM ANTIVIRUS CONFIGURATION
+By default
 .Nm
-expects that Clam AntiVirus's
+expects Clam AntiVirus'
 .Xr clamd 1
 to listen on 127.0.0.1 port 3310 for incoming requests.
 This requires to uncomment the TCPAddr and TCPSocket option in the default

--- a/extras/wip/filters/filter-clamav/filter-clamav.8
+++ b/extras/wip/filters/filter-clamav/filter-clamav.8
@@ -34,7 +34,7 @@ daemon.
 Mails are piped to the daemon, which scans the mail for viruses.
 .Pp
 The options are as follows:
-.Bl -tag -width "-d"
+.Bl -tag -width "-h host"
 .It Fl c
 No chroot(), if this option is specififed,
 .Nm

--- a/extras/wip/filters/filter-clamav/filter-clamav.8
+++ b/extras/wip/filters/filter-clamav/filter-clamav.8
@@ -21,7 +21,7 @@
 .Nd smtpd filter for Clam AntiVirus clamd
 .Sh SYNOPSIS
 .Nm
-.Op Fl dv
+.Op Fl cdv
 .Op Fl h Ar host
 .Op Fl p Ar port
 .Sh DESCRIPTION
@@ -35,15 +35,23 @@ Mails are piped to the daemon, which scans the mail for viruses.
 .Pp
 The options are as follows:
 .Bl -tag -width "-d"
+.It Fl c
+No chroot(), if this option is specififed,
+.Nm
+will not run chroot-ed allowing name resolution of the
+.Ar host
+parameter.
 .It Fl d
 Debug mode, if this option is specified,
 .Nm
 will run in the foreground and log to
 .Em stderr .
-.It Fl h
+.It Fl h Ar host
 Set the ClamAV
 .Ar host
-to be used.
+to be used. Use an IP-address or set
+.Ar -c
+if you require name-resolution.
 .Pp
 The default
 .Ar host

--- a/extras/wip/filters/filter-clamav/filter_clamav.c
+++ b/extras/wip/filters/filter-clamav/filter_clamav.c
@@ -260,13 +260,16 @@ clamav_on_rollback(uint64_t id)
 int
 main(int argc, char **argv)
 {
-	int ch, d = 0, v = 0;
+	int ch, c = 0, d = 0, v = 0;
 	char *h = NULL, *p = NULL;
 
 	log_init(1);
 
-	while ((ch = getopt(argc, argv, "dh:p:v")) != -1) {
+	while ((ch = getopt(argc, argv, "cdh:p:v")) != -1) {
 		switch (ch) {
+		case 'c':
+			c = 1;
+			break;
 		case 'd':
 			d = 1;
 			break;
@@ -304,6 +307,8 @@ main(int argc, char **argv)
 	filter_api_on_reset(clamav_on_reset);
 	filter_api_on_disconnect(clamav_on_disconnect);
 	filter_api_on_rollback(clamav_on_rollback);
+	if (c)
+		filter_api_no_chroot(); /* getaddrinfo requires resolv.conf */
 
 	filter_api_loop();
 	log_debug("debug: exiting");

--- a/extras/wip/filters/filter-spamassassin/filter_spamassassin.c
+++ b/extras/wip/filters/filter-spamassassin/filter_spamassassin.c
@@ -30,7 +30,7 @@
 #include "log.h"
 #include "iobuf.h"
 
-static const char *spamassassin_host = "127.0.0.1", *spamassassin_port = "783"
+static const char *spamassassin_host = "127.0.0.1", *spamassassin_port = "783";
 
 struct spamassassin {
 	int fd, r;

--- a/extras/wip/filters/filter-spamassassin/filter_spamassassin.c
+++ b/extras/wip/filters/filter-spamassassin/filter_spamassassin.c
@@ -324,7 +324,7 @@ main(int argc, char **argv)
 {
 	int ch, d = 0, v = 0;
 	const char *errstr, *l = NULL;
-	char *s = NULL;
+	char *h = NULL, *p = NULL, *s = NULL;
 
 	log_init(1);
 


### PR DESCRIPTION
Add no-chroot option for users requiring name-resolution of the `-h host` parameter