### PR TITLE
uint8_t is defined in stdint.h, at least on Linux

### DIFF
--- a/api/rfc2822.h
+++ b/api/rfc2822.h
@@ -19,7 +19,9 @@
 #ifndef _RFC2822_H_
 #define	_RFC2822_H_
 
+#ifdef HAVE_STDINT_H
 #include <stdint.h>
+#endif
 
 #define	RFC2822_MAX_LINE_SIZE		4096
 

--- a/api/rfc2822.h
+++ b/api/rfc2822.h
@@ -19,6 +19,8 @@
 #ifndef _RFC2822_H_
 #define	_RFC2822_H_
 
+#include <stdint.h>
+
 #define	RFC2822_MAX_LINE_SIZE		4096
 
 struct rfc2822_line {


### PR DESCRIPTION
Building current `master` otherwise fails due to unknown types. I can't test this change with *BSD, so somebody with more experience at cross-platform C might want to chime in on whether this needs to be wrapped in additional `#ifdef`s.