### PR TITLE
There is no sockaddr->sa_len on many Unix derivates.

### DIFF
--- a/api/mproc.c
+++ b/api/mproc.c
@@ -567,8 +567,8 @@ m_add_msgid(struct mproc *m, uint32_t v)
 void
 m_add_sockaddr(struct mproc *m, const struct sockaddr *sa)
 {
-	m_add_size(m, sa->sa_len);
-	m_add(m, sa, sa->sa_len);
+	m_add_size(m, SA_LEN(sa));
+	m_add(m, sa, SA_LEN(sa));
 }
 
 void


### PR DESCRIPTION
This fix using `SA_LEN()` afaict should work cross-platform, especially since code pre cf3b13c15b78bcae1e60ec1fe595f45fcc208475 relied on it as well.

@ericfaurot This is my attempt to address my comments at https://github.com/OpenSMTPD/OpenSMTPD-extras/commit/cf3b13c15b78bcae1e60ec1fe595f45fcc208475#commitcomment-19655261 (still hoping you are the correct person on that commit and I apologize if you're not ;) ).