### PR TITLE
handle PQresultErrorField returning NULL

### DIFF
--- a/extras/tables/table-postgres/table_postgres.c
+++ b/extras/tables/table-postgres/table_postgres.c
@@ -384,7 +384,9 @@ table_postgres_query(const char *key, int service)
 
 	if (PQresultStatus(res) != PGRES_TUPLES_OK) {
 		errfld = PQresultErrorField(res, PG_DIAG_SQLSTATE);
-		if (errfld[0] == '0' && errfld[1] == '8') {
+		/* PQresultErrorField can return NULL if the connection to the server
+		   suddenly closed (e.g. server restart) */
+		if (errfld == NULL || (errfld[0] == '0' && errfld[1] == '8')) {
 			log_warnx("warn: table-postgres: trying to reconnect after error: %s",
 			    PQerrorMessage(config->db));
 			PQclear(res);


### PR DESCRIPTION
This fixes a segfault which is caused by `PQresultErrorField` returning `NULL`, which can happen in certain cases, most notably if the PostgreSQL server itself or intermediate software like a haproxy loadbalancer closes the connection without notice.

See [the docs](https://www.postgresql.org/docs/9.6/static/libpq-exec.html#LIBPQ-PQRESULTERRORFIELD):
> NULL is returned if the PGresult is not an error or warning result, or does not include the specified field.

This PR fixes the segfault on my testing setup.

More details can be found in other projects that had to deal with the same issue, like [this one at citusdata](https://github.com/citusdata/citus/issues/634).

Stacktrace dump from GDB for context:
```
Program received signal SIGSEGV, Segmentation fault.
table_postgres_query (key=0x238eb4c "(redacted)", service=4)
    at ../../../../extras/wip/tables/table-postgres/table_postgres.c:405
405                     if (errfld[0] == '0' && errfld[1] == '8') {
(gdb) bt
#0  table_postgres_query (key=0x238eb4c "(redacted email address)", service=4)
    at ../../../../extras/wip/tables/table-postgres/table_postgres.c:405
#1  0x0000000000404502 in table_postgres_lookup (service=4, params=0x43,
    key=0x0, dst=0x7ffc3e35ceb0 "", sz=4096)
    at ../../../../extras/wip/tables/table-postgres/table_postgres.c:451
#2  0x000000000040254c in table_msg_dispatch ()
    at ../../../../api/table_api.c:212
#3  0x00000000004027d9 in table_api_dispatch ()
    at ../../../../api/table_api.c:324
#4  0x00000000004016a2 in main (argc=<optimized out>, argv=<optimized out>)
    at ../../../../extras/wip/tables/table-postgres/table_postgres.c:123
```