### PR TITLE
remove redundant definitions for with-user-smtpd and add with-user-queue

### DIFF
--- a/api/smtpd-defines.h
+++ b/api/smtpd-defines.h
@@ -66,9 +66,7 @@ enum smtp_proc_type {
 #define	SMTPD_MAXHOSTNAMELEN	256
 #define	SMTPD_MAXLINESIZE	2048
 
-#define SMTPD_USER		"_smtpd"
 #define PATH_CHROOT		"/var/empty"
-#define SMTPD_QUEUE_USER	 "_smtpq"
 #define PATH_SPOOL		"/var/spool/smtpd"
 
 #define TAG_CHAR	'+'	/* gilles+tag@ */

--- a/configure.ac
+++ b/configure.ac
@@ -644,8 +644,8 @@ AC_DEFINE_UNQUOTED([SMTPD_USER], ["$SMTPD_USER"],
 AC_SUBST([SMTPD_USER])
 
 SMTPD_QUEUE_USER=_smtpq
-AC_ARG_WITH([queue-user-smtpd],
-    [  --with-queue-user-smtpd=user Specify non-privileged user for accessing the message queue with privilege separation (default=_smtpq)],
+AC_ARG_WITH([user-queue],
+    [  --with-user-queue=user Specify non-privileged user for accessing the message queue with privilege separation (default=_smtpq)],
     [
         if test -n "$withval"  &&  test "x$withval" != "xno"  &&  \
             test "x${withval}" != "xyes"; then

--- a/configure.ac
+++ b/configure.ac
@@ -643,6 +643,20 @@ AC_DEFINE_UNQUOTED([SMTPD_USER], ["$SMTPD_USER"],
 	[non-privileged user for privilege separation])
 AC_SUBST([SMTPD_USER])
 
+SMTPD_QUEUE_USER=_smtpq
+AC_ARG_WITH([queue-user-smtpd],
+    [  --with-queue-user-smtpd=user Specify non-privileged user for accessing the message queue with privilege separation (default=_smtpq)],
+    [
+        if test -n "$withval"  &&  test "x$withval" != "xno"  &&  \
+            test "x${withval}" != "xyes"; then
+            SMTPD_QUEUE_USER=$withval
+        fi
+    ]
+)
+AC_DEFINE_UNQUOTED([SMTPD_QUEUE_USER], ["$SMTPD_QUEUE_USER"],
+    [non-privileged user for accessing the message queue with privilege separation])
+AC_SUBST([SMTPD_QUEUE_USER])
+
 # Checks for typedefs, structures, and compiler characteristics.
 AC_TYPE_MODE_T
 AC_TYPE_OFF_T


### PR DESCRIPTION
While experimenting with OpenSMTPD plugins, I ran into the problem that the `SMTPD_USER_*` definitions in `smtpd-defines.h` lead to problems with `#include` orders relative to `config.h`. I built filters and table processes that would fail on calls to `getpwnam()` assuming that they should use `_smtpd` instead of the value from `config.h` which was the Debian value `opensmtpd`.

The reason for this is that a lot of code in the API includes `smtpd-defines.h` thereby making it impossible to guess which value will win out.

Since Debian also uses `opensmtpq` for queue access, I added a respective configuration option to `configure.ac`, thereby making both configurable and removing the redundant `#define`s.

Symptoms when running filters compiled against `smtpd-defines.h` were, for example during smtpd startup:
```
greylistd[32071]: debug: starting...
greylistd[32071]: warn: filter-api:greylistd getpwnam: Success
                                             ^^ this is a call to getpwnam with the non-existent user "_smtpd"
greylistd[32071]: fatal: filter-api: exiting
```

and warning signs during compiling:

```
In file included from filter_greylistd.c:30:0:
opensmtpd-extras/api/smtpd-defines.h:69:0: warning: "SMTPD_USER" redefined
 #define SMTPD_USER  "_smtpd"
 ^
In file included from filter_greylistd.c:29:0:
opensmtpd-extras/config.h:400:0: note: this is the location of the previous defi
nition
 #define SMTPD_USER "opensmtpd"
 ^
In file included from opensmtpd-extras/openbsd-compat/sys/tree.h:29:0,
                 from opensmtpd-extras/api/smtpd-api.h:24,
                 from filter_greylistd.c:31:
opensmtpd-extras/config.h:400:0: warning: "SMTPD_USER" redefined
 #define SMTPD_USER "opensmtpd"
 ^
In file included from filter_greylistd.c:30:0:
opensmtpd-extras/api/smtpd-defines.h:69:0: note: this is the location of the pre
vious definition
 #define SMTPD_USER  "_smtpd"
 ^
```