### PR TITLE
Use larger 64KB buffer for rspamd communication

### DIFF
--- a/extras/filters/filter-rspamd/rspamd.c
+++ b/extras/filters/filter-rspamd/rspamd.c
@@ -61,7 +61,7 @@ transaction_allocator(uint64_t id)
 	tx = xcalloc(1, sizeof *tx, "transaction_allocator");
 	tx->id = id;
 
-	iobuf_xinit(&tx->iobuf, LINE_MAX, LINE_MAX, "on_eom");
+	iobuf_xinit(&tx->iobuf, 0, 0, "on_eom");
 	io_init(&tx->io, -1, tx, rspamd_io, &tx->iobuf);
 
 	dict_init(&tx->rcpts);


### PR DESCRIPTION
rspamd interface uses JSON not SMTP protocol, therefore does not obey
LINE_MAX (2048), but usually have longer response. Therefore with
latest rspamd, the response does not fit the 2048 anymore, and this
leads to error 421 when parsing JSON and IO_DISCONNECTION.

Using default 64KB buffer setting solves the issue. (#783)