### PR TITLE
Provide remote IP address not local IP to rspamd

### DIFF
--- a/extras/filters/filter-rspamd/filter_rspamd.c
+++ b/extras/filters/filter-rspamd/filter_rspamd.c
@@ -40,7 +40,7 @@ on_connect(uint64_t id, struct filter_connect *conn)
 	struct session	*rs = filter_api_session(id);
 	const char	*ip;
 
-	ip = filter_api_sockaddr_to_text((struct sockaddr *)&conn->local);
+	ip = filter_api_sockaddr_to_text((struct sockaddr *)&conn->remote);
 	if (! session_set_ip(rs, ip ? ip : "127.0.0.1"))
 		return filter_api_reject_code(id, FILTER_FAIL, 421,
 		    "temporary failure");


### PR DESCRIPTION
Rspamd is expecting sender's IP address not our own IP address in its
HTTP protocol IP: header. Providing our own IP instead of sender's IP
makes rspam really ineffective - particularly all known spammer IP list
checks.

  https://rspamd.com/doc/architecture/protocol.html

P.S. I know that you are in transition to new filter solution, anyway I think it is good to have it fixed, since I expect this code will be reused for the new OpenSMTPd filter solution.