### PR TITLE
Fix comment typo in config

### DIFF
--- a/extras/filters/filter-monkey/filter-monkey.conf
+++ b/extras/filters/filter-monkey/filter-monkey.conf
@@ -1,4 +1,4 @@
-# opensmptd-extras filter-monkey configuration
+# opensmtpd-extras filter-monkey configuration
 
 # add random delay on connect and end of message
 #delay 0:500 on connect


### PR DESCRIPTION
Fix a small typo discovered while reading through configs