### PR TITLE
Small changes to make table-mysql and tool-stats work on CentOS 7.

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -36,7 +36,7 @@ aclocalflags="`sed -ne 's/^[ \t]*ACLOCAL_AMFLAGS[ \t]*=//p' Makefile.am 2>/dev/n
 
 # Check for automake
 amvers="no"
-for v in 15 14; do
+for v in 15 14 13; do
   if automake-1.${v} --version >/dev/null 2>&1; then
     amvers="-1.${v}"
     break
@@ -48,7 +48,7 @@ done
 
 if test "${amvers}" = "no" && automake --version > /dev/null 2>&1; then
   amvers="`automake --version | sed -e '1s/[^0-9]*//' -e q`"
-  if `echo "$amvers\n1.14" | sort -V | head -n 1 | grep -q "$amvers"`; then
+  if `echo "$amvers\n1.13" | sort -V | head -n 1 | grep -q "$amvers"`; then
     amvers="no"
   else
     amvers=""
@@ -56,7 +56,7 @@ if test "${amvers}" = "no" && automake --version > /dev/null 2>&1; then
 fi
 
 if test "$amvers" = "no"; then
-  echo "$0: you need automake version 1.14 or later"
+  echo "$0: you need automake version 1.13 or later"
   exit 1
 fi
 
@@ -148,4 +148,3 @@ fi
 
 # Remove cruft that we no longer want
 rm -Rf autom4te.cache
-

--- a/configure.ac
+++ b/configure.ac
@@ -1134,6 +1134,19 @@ AC_ARG_WITH([table-mysql],
 			AC_DEFINE([HAVE_TABLE_MYSQL], [1],
 				[Define if you have experimental MySQL support])
 			HAVE_TABLE_MYSQL=yes
+			AC_PATH_PROG([MYSQL_CONFIG], [mysql_config], , $PATH/usr/bin:/usr/local/bin:/usr/local/mysql/bin)
+			if test "x$MYSQL_CONFIG" = "x"; then
+				AC_MSG_RESULT([mysql_config not found, proceeding with default settings])
+			else
+				AC_MSG_CHECKING([for MySQL lib path])
+				MYSQL_LIBS=`"$MYSQL_CONFIG" --libs | sed -n 's#.*-L\(\"/[^\"]*\"\).*#\1#p;s#.*-L\(/[^[:space:]]*\).*#\1#p;'`
+				if test "x$MYSQL_LIBS" = "x"; then
+					AC_MSG_RESULT([not found, proceeding with default settings])
+				else
+					AC_MSG_RESULT([found $MYSQL_LIBS])
+					LDFLAGS="-L${MYSQL_LIBS} ${LDFLAGS}"
+				fi
+			fi
 		fi
 	]
 )

--- a/extras/tables/table-mysql/Makefile.am
+++ b/extras/tables/table-mysql/Makefile.am
@@ -6,4 +6,4 @@ pkglibexec_PROGRAMS	 = table-mysql
 table_mysql_SOURCES	 = $(SRCS)
 table_mysql_SOURCES	+= table_mysql.c
 
-LDADD	+= -lmysqlclient
+LDADD	+= -L/usr/lib64/mysql -lmysqlclient

--- a/extras/tables/table-mysql/Makefile.am
+++ b/extras/tables/table-mysql/Makefile.am
@@ -6,4 +6,4 @@ pkglibexec_PROGRAMS	 = table-mysql
 table_mysql_SOURCES	 = $(SRCS)
 table_mysql_SOURCES	+= table_mysql.c
 
-LDADD	+= -L/usr/lib64/mysql -lmysqlclient
+LDADD	+= -lmysqlclient

--- a/extras/tools/tool-stats/tool_stats.c
+++ b/extras/tools/tool-stats/tool_stats.c
@@ -14,6 +14,8 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
+#define _XOPEN_SOURCE 700
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>


### PR DESCRIPTION
I had to drop bootstrap from automake 1.14 to accept 1.13 to make it work on CentOS 7 which ships with 1.13.

Also table-mysql failed to find mysqlclient because it didn't look in the right directory on CentOS7.