### PR TITLE
Fix compatibility with opensmtpd 5.9+

### DIFF
--- a/api/filter_api.c
+++ b/api/filter_api.c
@@ -652,8 +652,8 @@ filter_io_in(struct io *io, int evt)
 	case IO_DATAIN:
 	    nextline:
 		line = iobuf_getline(&s->pipe.ibuf, &len);
-		if ((line == NULL && iobuf_len(&s->pipe.ibuf) >= SMTPD_MAXLINESIZE) ||
-		    (line && len >= SMTPD_MAXLINESIZE)) {
+		if ((line == NULL && iobuf_len(&s->pipe.ibuf) >= LINE_MAX) ||
+		    (line && len >= LINE_MAX)) {
 			s->pipe.error = 1;
 			break;
 		}
@@ -1210,7 +1210,7 @@ filter_api_sockaddr_to_text(const struct sockaddr *sa)
 const char *
 filter_api_mailaddr_to_text(const struct mailaddr *maddr)
 {
-	static char  buffer[SMTPD_MAXLINESIZE];
+	static char  buffer[LINE_MAX];
 
 	strlcpy(buffer, maddr->user, sizeof buffer);
 	if (maddr->domain[0] == '\0')

--- a/api/queue_api.c
+++ b/api/queue_api.c
@@ -111,7 +111,7 @@ queue_msg_dispatch(void)
 	uint64_t	 evpid;
 	uint32_t	 msgid, version;
 	size_t		 n, m;
-	char		 buffer[8192], path[SMTPD_MAXPATHLEN];
+	char		 buffer[8192], path[PATH_MAX];
 	int		 r, fd;
 	FILE		*ifile, *ofile;
 

--- a/api/queue_utils.c
+++ b/api/queue_utils.c
@@ -59,7 +59,7 @@ int
 mktmpfile(void)
 {
 	static char	*tempdir = "/temporary";
-	char		 path[SMTPD_MAXPATHLEN];
+	char		 path[PATH_MAX];
 	int		 fd;
 	mode_t		 omode;
 

--- a/api/smtpd-api.h
+++ b/api/smtpd-api.h
@@ -27,6 +27,7 @@
 #include <stdio.h>
 #include <netinet/in.h>
 #include <netdb.h>
+#include <limits.h>
 
 #include <event.h>
 #include <imsg.h>
@@ -229,7 +230,7 @@ struct scheduler_info {
 
 struct table_open_params {
 	uint32_t	version;
-	char		name[SMTPD_MAXLINESIZE];
+	char		name[LINE_MAX];
 };
 
 enum table_service {

--- a/api/smtpd-defines.h
+++ b/api/smtpd-defines.h
@@ -61,11 +61,6 @@ enum smtp_proc_type {
 #define SMTPD_MAXLOCALPARTSIZE	 (255 + 1)
 #define SMTPD_MAXDOMAINPARTSIZE	 (255 + 1)
 
-#define	SMTPD_MAXLOGNAME	32
-#define	SMTPD_MAXPATHLEN	1024
-#define	SMTPD_MAXHOSTNAMELEN	256
-#define	SMTPD_MAXLINESIZE	2048
-
 #define SMTPD_USER		"_smtpd"
 #define PATH_CHROOT		"/var/empty"
 #define SMTPD_QUEUE_USER	 "_smtpq"

--- a/api/to.c
+++ b/api/to.c
@@ -92,7 +92,7 @@ text_to_mailaddr(struct mailaddr *maddr, const char *email)
 {
 	char *username;
 	char *hostname;
-	char  buffer[SMTPD_MAXLINESIZE];
+	char  buffer[LINE_MAX];
 
 	if (strlcpy(buffer, email, sizeof buffer) >= sizeof buffer)
 		return 0;
@@ -129,7 +129,7 @@ text_to_mailaddr(struct mailaddr *maddr, const char *email)
 const char *
 mailaddr_to_text(const struct mailaddr *maddr)
 {
-	static char  buffer[SMTPD_MAXLINESIZE];
+	static char  buffer[LINE_MAX];
 
 	(void)strlcpy(buffer, maddr->user, sizeof buffer);
 	(void)strlcat(buffer, "@", sizeof buffer);

--- a/extras/tables/table-mysql/table_mysql.c
+++ b/extras/tables/table-mysql/table_mysql.c
@@ -68,7 +68,7 @@ static void		 config_free(struct config *);
 #define	DEFAULT_REFRESH	1000
 
 static MYSQL_BIND	 results[SQL_MAX_RESULT];
-static char		 results_buffer[SQL_MAX_RESULT][SMTPD_MAXLINESIZE];
+static char		 results_buffer[SQL_MAX_RESULT][LINE_MAX];
 static char		*conffile;
 static struct config	*config;
 
@@ -333,7 +333,7 @@ table_mysql_query(const char *key, int service)
 	MYSQL_STMT	*stmt;
 	MYSQL_BIND	 param[1];
 	unsigned long	 keylen;
-	char		 buffer[SMTPD_MAXLINESIZE];
+	char		 buffer[LINE_MAX];
 	int		 i;
 
 retry:
@@ -586,7 +586,7 @@ main(int argc, char **argv)
 	for (i = 0; i < SQL_MAX_RESULT; i++) {
 		results[i].buffer_type = MYSQL_TYPE_STRING;
 		results[i].buffer = results_buffer[i];
-		results[i].buffer_length = SMTPD_MAXLINESIZE;
+		results[i].buffer_length = LINE_MAX;
 		results[i].is_null = 0;
 	}
 


### PR DESCRIPTION
This mirrors changes done in [1].

When a table from extras is used (tested with passwd and postgres),
opensmtpd failes to start (on Alpine Linux):

    passwd[7508]: warn: table-proc: bogus data
    passwd[7508]: fatal: table-proc: exiting
    warn: table-proc: pipe closed
    fatal: table-proc: exiting

The error is printed by the table process and it's cased by mismatch
between expected and actual size of the struct table_open_params.

Note: I've originally tried to port even changes of includes from [1],
but that would need to add many new includes to most of the extras.
Thus I've eventually decided that it's probably not the right approach.

Fixes: https://github.com/OpenSMTPD/OpenSMTPD/issues/816

[1]: https://github.com/OpenSMTPD/OpenSMTPD/commit/5dfecad33e1301343473f7e9a6e425cdd11b9c3f