### PR TITLE
Bind with LDAP user credentials to authenticate user

### DIFF
--- a/api/smtpd-api.h
+++ b/api/smtpd-api.h
@@ -234,18 +234,22 @@ struct table_open_params {
 };
 
 enum table_service {
-	K_NONE		= 0x000,
-	K_ALIAS		= 0x001,	/* returns struct expand	*/
-	K_DOMAIN	= 0x002,	/* returns struct destination	*/
-	K_CREDENTIALS	= 0x004,	/* returns struct credentials	*/
-	K_NETADDR	= 0x008,	/* returns struct netaddr	*/
-	K_USERINFO	= 0x010,	/* returns struct userinfo	*/
-	K_SOURCE	= 0x020,	/* returns struct source	*/
-	K_MAILADDR	= 0x040,	/* returns struct mailaddr	*/
-	K_ADDRNAME	= 0x080,	/* returns struct addrname	*/
-	K_MAILADDRMAP	= 0x100,	/* returns struct mailaddr	*/
+	K_NONE		= 00x000,
+	K_ALIAS		= 0x0001,	/* returns struct expand	*/
+	K_DOMAIN	= 0x0002,	/* returns struct destination	*/
+	K_CREDENTIALS	= 0x0004,	/* returns struct credentials	*/
+	K_NETADDR	= 0x0008,	/* returns struct netaddr	*/
+	K_USERINFO	= 0x0010,	/* returns struct userinfo	*/
+	K_SOURCE	= 0x0020,	/* returns struct source	*/
+	K_MAILADDR	= 0x0040,	/* returns struct mailaddr	*/
+	K_ADDRNAME	= 0x0080,	/* returns struct addrname	*/
+	K_MAILADDRMAP	= 0x0100,	/* returns struct mailaddr	*/
+	K_RELAYHOST	= 0x0200,	/* returns struct relayhost     */
+	K_STRING	= 0x0400,
+	K_REGEX		= 0x0800,
+	K_CHECKUSER	= 0x1000,	/* checks user credentials	*/
 };
-#define K_ANY		  0xfff
+#define K_ANY		  0xffff
 
 enum {
 	PROC_TABLE_OK,

--- a/extras/tables/table-ldap/table_ldap.c
+++ b/extras/tables/table-ldap/table_ldap.c
@@ -501,8 +501,9 @@ table_ldap_check(int service, struct dict *params, const char *key)
 		log_debug("debug: table-ldap: reconnecting");
 		if (!(ret = ldap_open())) {
 			log_warnx("warn: table-ldap: failed to connect");
+			return ret;
 		}
-		return ret;
+		return ldap_run_query(service, key, NULL, 0);
 	default:
 		return -1;
 	}

--- a/extras/tables/table-ldap/table_ldap.c
+++ b/extras/tables/table-ldap/table_ldap.c
@@ -333,7 +333,7 @@ table_ldap_lookup(int service, struct dict *params, const char *key, char *dst, 
 	case K_CREDENTIALS:
 	case K_USERINFO:
 	case K_MAILADDR:
-		if ((ret = ldap_run_query(service, key, dst, sz)) > 0) {
+		if ((ret = ldap_run_query(service, key, dst, sz)) >= 0) {
 			return ret;
 		}
 		log_debug("debug: table-ldap: reconnecting");

--- a/extras/tables/table-ldap/table_ldap.c
+++ b/extras/tables/table-ldap/table_ldap.c
@@ -386,10 +386,13 @@ ldap_query(const char *filter, char **attributes, char ***outp, size_t n)
 			if (m->message_type != LDAP_RES_SEARCH_ENTRY)
 				goto error;
 
+			if (found)
+				goto next;
 			found = 1;
 			for (i = 0; i < n; ++i)
 				if (aldap_match_attr(m, attributes[i], &outp[i]) != 1)
 					goto error;
+next:
 			aldap_freemsg(m);
 			m = NULL;
 		}


### PR DESCRIPTION
Some servers (like OpenLDAP)  doesn't store the password using the crypt method. So we can't just query the user and password with K_CREDENTIALS table service because crypt_checkpass(3) will fail in the lka.

So use K_CHECKUSER (from https://github.com/OpenSMTPD/OpenSMTPD/pull/903) instead and let the backend verify the password for us.

First try to solve https://github.com/OpenSMTPD/OpenSMTPD/issues/812.