### PR TITLE
Fix bug in table_socketmap: error check of getline

### DIFF
--- a/extras/tables/table-socketmap/table_socketmap.c
+++ b/extras/tables/table-socketmap/table_socketmap.c
@@ -95,7 +95,7 @@ table_socketmap_query(const char *name, const char *key)
 	fprintf(sockstream, "%s %s\n", name, key);
 	fflush(sockstream);
 
-	if ((len = getline(&buf, &sz, sockstream)) != -1) {
+	if ((len = getline(&buf, &sz, sockstream)) == -1) {
 		log_warnx("warn: socketmap has lost its socket");
 		(void)strlcpy(repbuffer, "lost connection to socket", sizeof repbuffer);
 		ret = SM_PERM;


### PR DESCRIPTION
Previously, if the return value of `getline` was not equal to `-1`,
`table-socketmap` would warn and go to an error state.  In fact, `getline`
signals an error by returning `-1`. Hence, the program would go into an
error state when `getline` indicated that no error had occurred.

Now, `table-socketmap` only moves to an error state when getline returns
an error.

This bug made `table-socketmap` completely unusable for me. Now, it works like a charm. 