### PR TITLE
readd filter-stub

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1590,6 +1590,9 @@ AC_CONFIG_FILES([Makefile
 		extras/tables/table-socketmap/Makefile
 		extras/tables/table-sqlite/Makefile
 		extras/tables/table-stub/Makefile
+
+		extras/filters/Makefile
+		extras/filters/filter-stub/Makefile
 		])
 
 #l4761

--- a/extras/Makefile.am
+++ b/extras/Makefile.am
@@ -1,3 +1,4 @@
 SUBDIRS=	queues
 SUBDIRS+=	schedulers
 SUBDIRS+=	tables
+SUBDIRS+=	filters

--- a/extras/filters/Makefile.am
+++ b/extras/filters/Makefile.am
@@ -1,0 +1,5 @@
+SUBDIRS =
+
+if HAVE_FILTER_STUB
+SUBDIRS+=	filter-stub
+endif

--- a/extras/filters/filter-stub/Makefile.am
+++ b/extras/filters/filter-stub/Makefile.am
@@ -1,0 +1,10 @@
+include $(top_srcdir)/mk/paths.mk
+include $(top_srcdir)/mk/filter.mk
+include $(top_srcdir)/mk/experimental.mk
+
+pkglibexec_PROGRAMS	 = filter-stub
+
+filter_stub_SOURCES	 = $(SRCS)
+filter_stub_SOURCES	+= filter_stub.c
+
+man_MANS		 = filter-stub.8

--- a/extras/filters/filter-stub/filter-stub.8
+++ b/extras/filters/filter-stub/filter-stub.8
@@ -1,0 +1,59 @@
+.\"
+.\" Copyright (c) 2015, 2016 Joerg Jung <jung@openbsd.org>
+.\"
+.\" Permission to use, copy, modify, and distribute this software for any
+.\" purpose with or without fee is hereby granted, provided that the above
+.\" copyright notice and this permission notice appear in all copies.
+.\"
+.\" THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+.\" WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+.\" MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+.\" ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+.\" WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+.\" ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+.\" OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+.\"
+.Dd $Mdocdate: May 16 2016 $
+.Dt FILTER-STUB 8
+.Os
+.Sh NAME
+.Nm filter-stub
+.Nd smtpd filter stub
+.Sh SYNOPSIS
+.Nm
+.Op Fl dv
+.Sh DESCRIPTION
+.Nm
+is a stub filter for
+.Xr smtpd 8
+which accepts all mails.
+The purpose of this filter is to provide a code template for other filters.
+.Pp
+The options are as follows:
+.Bl -tag -width "-d"
+.It Fl d
+Debug mode, if this option is specified,
+.Nm
+will run in the foreground and log to
+.Em stderr .
+.It Fl v
+Produce more verbose output.
+.El
+.Pp
+.Nm
+runs by default in a chroot.
+.Pp
+The debug and verbose options given with the
+.Xr smtpd 8
+invocation are intially passed to
+.Nm .
+.Sh SEE ALSO
+.Xr filter_api 3 ,
+.Xr smtpd.conf 5 ,
+.Xr smtpd 8
+.Sh HISTORY
+The first version of
+.Nm
+was written in 2013.
+.Sh AUTHORS
+.An Eric Faurot Aq Mt eric@openbsd.org

--- a/extras/filters/filter-stub/filter_stub.c
+++ b/extras/filters/filter-stub/filter_stub.c
@@ -1,0 +1,179 @@
+/*
+ * Copyright (c) 2013 Eric Faurot <eric@openbsd.org>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#include "includes.h"
+
+#include <sys/types.h>
+
+#include <inttypes.h>
+#include <stdio.h>
+#include <unistd.h>
+
+#include <smtpd-api.h>
+
+static void *
+session_alloc(uint64_t id)
+{
+	return (void *)-1;
+}
+
+static void
+session_free(void *session)
+{
+}
+
+static void *
+transaction_alloc(uint64_t id)
+{
+	return (void *)-1;
+}
+
+static void
+transaction_free(void *transaction)
+{
+}
+
+static int
+on_connect(uint64_t id, struct filter_connect *conn)
+{
+	log_debug("debug: on_connect");
+	return filter_api_accept(id);
+}
+
+static int
+on_helo(uint64_t id, const char *helo)
+{
+	log_debug("debug: on_helo");
+	return filter_api_accept(id);
+}
+
+static int
+on_mail(uint64_t id, struct mailaddr *mail)
+{
+	log_debug("debug: on_mail");
+	return filter_api_accept(id);
+}
+
+static int
+on_rcpt(uint64_t id, struct mailaddr *rcpt)
+{
+	log_debug("debug: on_rcpt");
+	return filter_api_accept(id);
+}
+
+static int
+on_data(uint64_t id)
+{
+	log_debug("debug: on_data");
+	return filter_api_accept(id);
+}
+
+static int
+on_eom(uint64_t id, size_t size)
+{
+	log_debug("debug: on_eom");
+	return filter_api_accept(id);
+}
+
+static void
+on_dataline(uint64_t id, const char *line)
+{
+	log_debug("debug: on_dataline");
+	filter_api_writeln(id, line);
+}
+
+static void
+on_reset(uint64_t id)
+{
+	log_debug("debug: on_reset");
+}
+
+static void
+on_tx_begin(uint64_t id)
+{
+	log_debug("debug: on_tx_begin");
+}
+
+static void
+on_tx_commit(uint64_t id)
+{
+	log_debug("debug: on_tx_commit");
+}
+
+static void
+on_tx_rollback(uint64_t id)
+{
+	log_debug("debug: on_tx_rollback");
+}
+
+static void
+on_disconnect(uint64_t id)
+{
+	log_debug("debug: on_disconnect");
+}
+
+int
+main(int argc, char **argv)
+{
+	int ch, d = 0, v = 0;
+
+	log_init(1);
+
+	while ((ch = getopt(argc, argv, "dv")) != -1) {
+		switch (ch) {
+		case 'd':
+			d = 1;
+			break;
+		case 'v':
+			v |= TRACE_DEBUG;
+			break;
+		default:
+			log_warnx("warn: bad option");
+			return 1;
+			/* NOTREACHED */
+		}
+	}
+	argc -= optind;
+	argv += optind;
+
+	log_init(d);
+	log_verbose(v);
+
+	log_debug("debug: starting...");
+
+	filter_api_session_allocator(session_alloc);
+	filter_api_session_destructor(session_free);
+	filter_api_transaction_allocator(transaction_alloc);
+	filter_api_transaction_destructor(transaction_free);
+
+	filter_api_on_connect(on_connect);
+	filter_api_on_helo(on_helo);
+	filter_api_on_mail(on_mail);
+	filter_api_on_rcpt(on_rcpt);
+	filter_api_on_data(on_data);
+	filter_api_on_reset(on_reset);
+	filter_api_on_msg_end(on_eom);
+	filter_api_on_msg_line(on_dataline);
+	filter_api_on_tx_begin(on_tx_begin);
+	filter_api_on_tx_commit(on_tx_commit);
+	filter_api_on_tx_rollback(on_tx_rollback);
+	filter_api_on_disconnect(on_disconnect);
+
+	filter_api_loop();
+	log_debug("debug: exiting");
+
+	return 1;
+}


### PR DESCRIPTION
I have updated filter-stub to `FILTER_API_VERSION` 52 to start experimenting with the filter API again. I assume that it might be useful to have the stub in the main codebase?