### PR TITLE
support for mailaddrmap lookups in table-postgres

### DIFF
--- a/extras/tables/table-postgres/table_postgres.c
+++ b/extras/tables/table-postgres/table_postgres.c
@@ -40,6 +40,7 @@ enum {
 	SQL_SOURCE,
 	SQL_MAILADDR,
 	SQL_ADDRNAME,
+	SQL_MAILADDRMAP,
 
 	SQL_MAX
 };
@@ -234,6 +235,7 @@ config_connect(struct config *conf)
 		{ "query_source",	1 },
 		{ "query_mailaddr",	1 },
 		{ "query_addrname",	1 },
+		{ "query_mailaddrmap",	1 },
 	};
 	size_t	 i;
 	char	*conninfo, *q;
@@ -381,6 +383,7 @@ table_postgres_lookup(int service, struct dict *params, const char *key, char *d
 	r = 1;
 	switch(service) {
 	case K_ALIAS:
+	case K_MAILADDRMAP:
 		memset(dst, 0, sz);
 		for (i = 0; i < PQntuples(res); i++) {
 			if (dst[0] && strlcat(dst, ", ", sz) >= sz) {


### PR DESCRIPTION
Currently lookups for K_MAILADDRMAP won't work with table-postgres. This PR enhances table-postgres to support them using "query_mailaddrmap" inside the config file.

table-sqlite also lacks support for K_MAILADDRMAP. If we're sure this patch is in a mergeable state I would also update table-sqlite in the same way.
