### PR TITLE
support for mailaddrmap lookups in table-mysql

### DIFF
--- a/extras/tables/table-mysql/table-mysql.5
+++ b/extras/tables/table-mysql/table-mysql.5
@@ -129,6 +129,15 @@ This is used to provide a query for looking up a domain. The question mark
 is replaced with the appropriate data. For the domain it would be the
 right hand side of the SMTP address. This expects one VARCHAR to be returned
 with a matching domain name.
+.Pp
+
+.It Xo
+.Ic query_mailaddrmap
+.Ar SQL statement
+.Xc
+This is used to provide a query to look up senders. The question mark
+is replaced with the appropriate data. This expects one VARCHAR to be
+returned with the address the sender is allowed to send mails from.
 .El
 
 A generic SQL statement would be something like:

--- a/extras/tables/table-mysql/table_mysql.c
+++ b/extras/tables/table-mysql/table_mysql.c
@@ -41,6 +41,7 @@ enum {
 	SQL_SOURCE,
 	SQL_MAILADDR,
 	SQL_ADDRNAME,
+	SQL_MAILADDRMAP,
 
 	SQL_MAX
 };
@@ -240,6 +241,7 @@ config_connect(struct config *conf)
 		{ "query_source",	1 },
 		{ "query_mailaddr",	1 },
 		{ "query_addrname",	1 },
+		{ "query_mailaddrmap",	1 },
 	};
 	my_bool	 reconn;
 	size_t	 i;
@@ -435,6 +437,7 @@ table_mysql_lookup(int service, struct dict *params, const char *key, char *dst,
 
 	switch(service) {
 	case K_ALIAS:
+	case K_MAILADDRMAP:
 		memset(dst, 0, sz);
 		do {
 			if (dst[0] && strlcat(dst, ", ", sz) >= sz) {


### PR DESCRIPTION
Similar to https://github.com/OpenSMTPD/OpenSMTPD-extras/pull/59:

Currently lookups for K_MAILADDRMAP won't work with table-mysql. This PR enhances table-mysql to support them using "query_mailaddrmap" inside the config file

@poolpOrg Do you plan a release together with opensmtpd 6.6?