### PR TITLE
Fix building with MySQL 8.0.1.

### DIFF
--- a/extras/tables/table-mysql/table_mysql.c
+++ b/extras/tables/table-mysql/table_mysql.c
@@ -243,7 +243,11 @@ config_connect(struct config *conf)
 		{ "query_addrname",	1 },
 		{ "query_mailaddrmap",	1 },
 	};
+#if MYSQL_VERSION_ID >= 80001
+	bool reconn;
+#else
 	my_bool	 reconn;
+#endif
 	size_t	 i;
 	char	*host, *username, *password, *database, *q;
 


### PR DESCRIPTION
MySQL removed the my_bool type in v8.0.1 ([patch notes](https://dev.mysql.com/doc/relnotes/mysql/8.0/en/news-8-0-1.html)).

Here is a patch I'm using when building with 5.7 and 8.0 MySQL libs now.